### PR TITLE
set broadcast mode block

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -15,6 +15,7 @@ MNEMONIC_FILE6=mnemonic6.txt
 interchain-queriesd init $MONIKER --chain-id $CHAINID
 
 interchain-queriesd config keyring-backend $KEYRING
+interchain-queriesd config broadcast-mode block
 
 interchain-queriesd keys add genkey --recover < $MNEMONIC_FILE1
 interchain-queriesd keys add relayer --recover < $MNEMONIC_FILE2


### PR DESCRIPTION
# Motivation
After executing init.sh, the chain created by interchain-queriesd has "sync" broadcast mode.

There are several broadcast modes as follows:
- sync: Wait for the tx to pass/fail CheckTx
- async: Don't wait for pass/fail CheckTx; send and return tx immediately
- block: Wait for the tx to pass/fail CheckTx, DeliverTx, and be committed in a block

If we send cross-chain query transaction in sync mode, we can't see query id in raw_log.

So we need to change broadcast mode to "block"

# What is changed

Add command changing broadcast mode in init.sh 